### PR TITLE
remove pixi script and use pixi-rocker instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This has basic setup for
 [![GitHub issues](https://img.shields.io/github/issues/blooop/python_template.svg)](https://GitHub.com/blooop/python_template/issues/)
 [![GitHub pull-requests merged](https://badgen.net/github/merged-prs/blooop/python_template)](https://github.com/blooop/python_template/pulls?q=is%3Amerged)
 [![GitHub release](https://img.shields.io/github/release/blooop/python_template.svg)](https://GitHub.com/blooop/python_template/releases/)
-[![License](https://img.shields.io/pypi/blooop/python_template)](https://opensource.org/license/mit/)
+[![License](https://img.shields.io/github/license/blooop/python_template)](https://opensource.org/license/mit/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org/downloads/)
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)
 

--- a/python_template.deps.yaml
+++ b/python_template.deps.yaml
@@ -10,6 +10,3 @@ apt_tools:
 
 pip_language-toolchain:
   - uv #use uv instead of pip
-
-script_pixi-user:
-  - scripts/install_pixi.sh

--- a/scripts/install_pixi.sh
+++ b/scripts/install_pixi.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-set -e
-curl -fsSL https://pixi.sh/install.sh | bash
-echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc

--- a/scripts/launch_vscode.sh
+++ b/scripts/launch_vscode.sh
@@ -40,7 +40,7 @@ if [ ! -d "$VENV_DIR" ]; then
     echo "Activating the virtual environment..."
     source $VENV_DIR/bin/activate
     echo "Installing deps rocker..."
-    pip install deps-rocker
+    pip install deps-rocker pixi-rocker
     echo "Virtual environment setup and deps rocker installation complete."
 else
     echo "Virtual environment already exists in $VENV_DIR."
@@ -49,7 +49,7 @@ else
 fi
 
 # Run the rocker command with the specified parameters
-rocker --nvidia --x11 --user --pull --git --image-name "$CONTAINER_NAME" --name "$CONTAINER_NAME" --volume "${PWD}":/workspaces/"${CONTAINER_NAME}":Z --deps --oyr-run-arg " --detach" ubuntu:22.04 "$@" 
+rocker --pixi --nvidia --x11 --user --pull --git --image-name "$CONTAINER_NAME" --name "$CONTAINER_NAME" --volume "${PWD}":/workspaces/"${CONTAINER_NAME}":Z --deps --oyr-run-arg " --detach" ubuntu:22.04 "$@" 
 
 deactivate
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Switch to using pixi-rocker instead of the pixi script in the launch_vscode.sh script, simplifying the setup by removing the install_pixi.sh script and its dependencies.

Enhancements:
- Replace the use of the pixi script with pixi-rocker in the launch_vscode.sh script to streamline the setup process.

Chores:
- Remove the install_pixi.sh script and its references from the project, as it is no longer needed.

<!-- Generated by sourcery-ai[bot]: end summary -->