### PR TITLE
ci: remove check clean workspace as part of ci

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,7 @@
 *.dae filter=lfs diff=lfs merge=lfs -text
 *.obj filter=lfs diff=lfs merge=lfs -text
 *.ply filter=lfs diff=lfs merge=lfs -text
+*.usd filter=lfs diff=lfs merge=lfs -text
 
 # Compiled libraries
 *.a filter=lfs diff=lfs merge=lfs -text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ update-lock-push = { depends_on = ["update-lock", "push"] }
 fix = { depends_on = ["update-lock", "format", "ruff-lint"] }
 fix-commit-push = { depends_on = ["fix", "commit-format", "update-lock-push"] }
 ci-no-cover = { depends_on = ["style", "test"] }
-ci = { depends_on = ["format","ruff-lint","check-clean-workspace","pylint", "coverage", "coverage-report"] }
+ci = { depends_on = ["format","ruff-lint", "pylint", "coverage", "coverage-report"] }
 ci-push = {depends_on=["format","ruff-lint","update-lock","ci","push"]}
 clear-pixi = "rm -rf .pixi pixi.lock"
 setup-git-merge-driver = "git config merge.ourslock.driver true"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove 'check-clean-workspace' from the CI workflow dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `.usd` file extension in Git LFS for improved handling of large files.

- **Bug Fixes**
	- Updated project version from 0.1.0 to 0.2.0, streamlining the continuous integration process by removing unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->