### PR TITLE
add codespell ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         types_or: [ python, pyi ]
   # Checks for spelling mistakes
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0 #TODO latest version  2.3.0 finds a lot of spelling mistakes but fails on "assertIn"
+    rev: v2.3.0 
     hooks:
       - id: codespell
         args: ["--write-changes","--ignore-words=./codespell-ignore.txt"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,8 +50,8 @@ repos:
         types_or: [ python, pyi ]
   # Checks for spelling mistakes
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0 
+    rev: v2.3.0 #TODO latest version  2.3.0 finds a lot of spelling mistakes but fails on "assertIn"
     hooks:
       - id: codespell
-        args: ['--write-changes']
-        exclude: \.(svg|pyc|lock|json)$
+        args: ["--write-changes","--ignore-words=./codespell-ignore.txt"]
+        exclude: \.(svg|pyc|lock|json|hrd|pgm)$

--- a/codespell-ignore.txt
+++ b/codespell-ignore.txt
@@ -1,0 +1,1 @@
+assertIn


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add a `codespell-ignore.txt` file to specify words that should be ignored by the codespell hook.