### PR TITLE
add cwd for rocker and remove lazygit

### DIFF
--- a/rockerc.yaml
+++ b/rockerc.yaml
@@ -13,5 +13,5 @@ args:
   - pull 
   - deps
   - git 
-  - lazygit
   - pixi
+  - cwd


### PR DESCRIPTION
## Summary by Sourcery

This pull request updates the rocker configuration file to remove `lazygit` and add `cwd` to the list of arguments passed to the rocker CLI tool.

Enhancements:
- Adds `cwd` to the list of arguments passed to the rocker CLI tool.

Chores:
- Removes `lazygit` from the list of arguments passed to the rocker CLI tool.