### PR TITLE
use dependson for node

### DIFF
--- a/.devcontainer/claude-code/devcontainer-feature.json
+++ b/.devcontainer/claude-code/devcontainer-feature.json
@@ -16,12 +16,9 @@
     "containerEnv": {
         "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
     },
-    "dependsOn": [
-        "ghcr.io/devcontainers/features/node"
-    ],
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/node"
-    ],
+    "dependsOn": {
+        "ghcr.io/devcontainers/features/node": {}
+    },
     "mounts": [
         "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/vscode/.claude/CLAUDE.md,type=bind,ro",
         "source=${localEnv:HOME}/.claude/settings.json,target=/home/vscode/.claude/settings.json,type=bind,ro",

--- a/.devcontainer/claude-code/install.sh
+++ b/.devcontainer/claude-code/install.sh
@@ -9,14 +9,13 @@ set -eu
 install_claude_code() {
     echo "Installing Claude Code CLI globally..."
 
-    # Verify Node.js and npm are available
+    # Verify Node.js and npm are available (should be installed via dependsOn)
     if ! command -v node >/dev/null || ! command -v npm >/dev/null; then
         cat <<EOF
 
 ERROR: Node.js and npm are required but not found!
 
-This should not happen as the Node.js feature is automatically installed
-via the 'installsAfter' mechanism in devcontainer-feature.json.
+This should not happen as the Node.js feature is declared in 'dependsOn'.
 
 Please check:
 1. The devcontainer feature specification is correct

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,6 @@
         }
     },
 	"features": {
-        "ghcr.io/devcontainers/features/node":{},
 		"./claude-code": {}
 
         // "ghcr.io/devcontainers/features/docker-in-docker:2": {}

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ managed_context/metadata.json
 test_suite_analysis/metadata.json
 
 .devpod/
+.devpod-internal/


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Clarify installation script messaging to reflect that Node.js is provided via devcontainer dependsOn configuration.