### PR TITLE
Fix devpod SSH tunneling and VS Code IDE launch issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ platforms = ["linux-64"]
 [tool.pixi.dependencies]
 python = ">=3.10"
 shellcheck = ">=0.10.0,<0.11"
-devpod = "*"
+devpod = ">=0.8.0,<0.9"
 
 [tool.pixi.feature.py310.dependencies]
 python = "3.10.*"
@@ -61,7 +61,7 @@ py312 = ["py312", "test"]
 py313 = ["py313", "test"]
 
 [tool.pixi.tasks]
-dev-add-docker = "devpod provider list | grep -q docker || devpod provider add docker"
+dev-add-docker = "devpod provider list | grep -qw docker || devpod provider add docker"
 dev = { cmd = "devpod up . --ide none && ssh pythontemplate.devpod", depends-on = ["dev-add-docker"] }
 dev-vs = { cmd = "devpod up . --ide vscode", depends-on = ["dev-add-docker"] }
 dev-restart = { cmd = "devpod up . --recreate --ide none && ssh pythontemplate.devpod", depends-on = ["dev-add-docker"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,10 @@ py313 = ["py313", "test"]
 
 [tool.pixi.tasks]
 dev-add-docker = "devpod provider list | grep -q docker || devpod provider add docker"
-dev = { cmd = "devpod up . --ide none && devpod ssh .", depends-on = ["dev-add-docker"] }
-dev-vs = { cmd = "devpod up .", depends-on = ["dev-add-docker"] }
-dev-restart = { cmd = "devpod up . --recreate --ide none && devpod ssh .", depends-on = ["dev-add-docker"] }
-dev-restart-vs = { cmd = "devpod up . --recreate", depends-on = ["dev-add-docker"] }
+dev = { cmd = "devpod up . --ide none && ssh pythontemplate.devpod", depends-on = ["dev-add-docker"] }
+dev-vs = { cmd = "devpod up . --ide vscode", depends-on = ["dev-add-docker"] }
+dev-restart = { cmd = "devpod up . --recreate --ide none && ssh pythontemplate.devpod", depends-on = ["dev-add-docker"] }
+dev-restart-vs = { cmd = "devpod up . --recreate --ide vscode", depends-on = ["dev-add-docker"] }
 pre-commit = "pre-commit run -a"
 pre-commit-update = "pre-commit autoupdate"
 format = "ruff format ."


### PR DESCRIPTION
## Summary
- Replace `devpod ssh .` with native `ssh pythontemplate.devpod` to fix TTY allocation issues causing "Error tunneling to container" errors in devpod v0.6.15
- Add explicit `--ide vscode` flag to `dev-vs` and `dev-restart-vs` tasks since no default IDE is configured in devpod

## Test plan
- [ ] Run `pixi r dev` - should SSH into the devcontainer without tunneling errors
- [ ] Run `pixi r dev-vs` - should launch VS Code and attach to the devcontainer
- [ ] Run `pixi r dev-restart` - should recreate container and SSH in
- [ ] Run `pixi r dev-restart-vs` - should recreate container and launch VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)