### PR TITLE
fix pixi issues with merge

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PIXI_VERSION=v0.62.2
+ARG PIXI_VERSION=v0.63.1
 
 RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \

--- a/scripts/rename_project.sh
+++ b/scripts/rename_project.sh
@@ -3,7 +3,10 @@
 mv python_template "$1"
 
 # change project name in all files
-find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/python_template/$1/g"
+find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh' -not -name 'pixi.lock' \) -print0 | xargs -0 sed -i "s/python_template/$1/g"
+
+# regenerate lockfile to match renamed project
+pixi update
 
 # author name
 if [ -n "$2" ]; then

--- a/scripts/update_from_template.sh
+++ b/scripts/update_from_template.sh
@@ -6,7 +6,13 @@ git fetch --all
 git checkout main && git pull origin main
 git checkout -B feature/update_from_template; git pull
 git merge template/main --allow-unrelated-histories -m 'feat: pull changes from remote template'
-git checkout --ours pixi.lock; git add pixi.lock
+git checkout --ours pixi.lock
+
+# regenerate lockfile to match merged pyproject.toml
+pixi update
+git add pixi.lock
+git diff --cached --quiet || git commit -m 'chore: update pixi.lock after template merge'
+
 git remote remove template
 git push --set-upstream origin feature/update_from_template
 git checkout main


### PR DESCRIPTION
## Summary by Sourcery

Regenerate the Pixi lockfile after template merges and project renaming instead of force-keeping the existing file, and exclude the lockfile from bulk search-and-replace operations during project rename.

Enhancements:
- Update the template sync script to regenerate and commit pixi.lock after merging template changes.
- Adjust the project rename script to avoid renaming inside pixi.lock and trigger a Pixi lockfile regeneration afterward.