### PR TITLE
fix: Fix pixi tasks for update-from-template and rename-project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,8 @@ ci = { depends-on = [
 ci-push = { depends-on = ["format", "ruff-lint", "update-lock", "ci", "push"] }
 clear-pixi = "rm -rf .pixi pixi.lock"
 setup-git-merge-driver = "git config merge.ourslock.driver true"
-update-from-template-repo = "./scripts/update_from_template.sh"
+update-from-template-repo = { cmd = "bash scripts/update_from_template.sh" }
+rename-project = { cmd = "bash scripts/rename_project.sh" }
 
 [tool.pylint]
 extension-pkg-whitelist = ["numpy"]


### PR DESCRIPTION
- Changed update-from-template-repo task to use explicit bash invocation
- Added rename-project task with proper bash invocation
- Removed ./ prefix from script paths (pixi runs from project root)
- Used { cmd = "..." } format for consistency with other complex tasks

This fixes issues where running via pixi tasks didn't work properly
compared to running the scripts directly.