### PR TITLE
Add prebuilt devcontainer image support via GHCR

### DIFF
--- a/.devcontainer/ci/devcontainer.json
+++ b/.devcontainer/ci/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "python_template-build",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "../.."
+    },
+    "features": {
+        "../claude-code": {}
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,20 @@
 {
     "name": "python_template",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "context": ".."
-    },
+
+    // Prebuilt image from GHCR (built by .github/workflows/devcontainer.yml)
+    // Features (including claude-code) are baked into this image.
+    "image": "ghcr.io/blooop/python_template/devcontainer:latest",
+
+    // To build locally instead of using the prebuilt image, comment out "image" above
+    // and uncomment the "build" and "features" blocks below:
+    // "build": {
+    //     "dockerfile": "Dockerfile",
+    //     "context": ".."
+    // },
+    // "features": {
+    //     "./claude-code": {}
+    // },
+
     "initializeCommand": ".devcontainer/claude-code/init-host.sh",
     "customizations": {
         "vscode": {
@@ -14,17 +25,10 @@
                 "jjjermiah.pixi-vscode",
                 "charliermarsh.ruff",
                 "tamasfe.even-better-toml",
-                "mhutchie.git-graph"
-              ]
+                "mhutchie.git-graph",
+                "anthropic.claude-code"
+            ]
         }
-    },
-	"features": {
-		"./claude-code": {}
-
-        // "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-		// "ghcr.io/devcontainers/features/common-utils:2": {},
-		// "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
-		// "ghcr.io/jsburckhardt/devcontainer-features/codex:latest": {}
     },
     "runArgs": [
         "--network=host"
@@ -39,7 +43,8 @@
     "mounts": [
         "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume",
         "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind",
-        "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind"
+        "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind",
+        "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
     ],
     "postCreateCommand": "sudo chown vscode .pixi && pixi install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,10 @@
     // },
     // "features": {
     //     "./claude-code": {}
+    //     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    //     "ghcr.io/devcontainers/features/common-utils:2": {},
+    //     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    //     "ghcr.io/jsburckhardt/devcontainer-features/codex:latest": {}
     // },
 
     "initializeCommand": ".devcontainer/claude-code/init-host.sh",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
         #try to group all third party library updates into a single pr
         patterns:
           - "*"
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,49 @@
+name: Devcontainer Image
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".devcontainer/**"
+      - ".github/workflows/devcontainer.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".devcontainer/**"
+      - ".github/workflows/devcontainer.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image metadata
+        id: meta
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          DATE=$(date +%Y-%m-%d)
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push devcontainer image
+        uses: devcontainers/ci@v0.3
+        with:
+          configFile: .devcontainer/ci/devcontainer.json
+          imageName: ghcr.io/${{ github.repository }}/devcontainer
+          imageTag: latest,sha-${{ steps.meta.outputs.short_sha }},${{ steps.meta.outputs.date }}
+          cacheFrom: ghcr.io/${{ github.repository }}/devcontainer:latest
+          push: ${{ github.event_name != 'pull_request' && 'always' || 'never' }}


### PR DESCRIPTION
- Add CI workflow to build and publish devcontainer image to ghcr.io
  on changes to .devcontainer/ files (with PR validation builds)
- Create .devcontainer/ci/ config for CI image builds with features baked in
- Update devcontainer.json to pull prebuilt image instead of building locally
  (local build instructions preserved as comments)
- Absorb claude-code feature runtime config (mount, extension) into
  devcontainer.json since features are pre-baked in the image
- Add docker ecosystem to dependabot for base image update tracking

https://claude.ai/code/session_01P15jZtANbd9QQm4SiY3Nzh

## Summary by Sourcery

Add support for a prebuilt devcontainer image published to GitHub Container Registry and wire it into local development.

New Features:
- Introduce a prebuilt devcontainer image consumed by devcontainer.json instead of building locally.

Build:
- Add a dedicated devcontainer CI configuration under .devcontainer/ci for building the image with required features pre-baked.

CI:
- Add a GitHub Actions workflow to build, tag, and publish the devcontainer image to GHCR on changes and pull requests.

Chores:
- Extend Dependabot configuration to track Docker updates for the devcontainer base image.