### PR TITLE
Document GHCR package visibility and how to make public

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,20 @@
 {
     "name": "python_template",
 
-    // Prebuilt image from GHCR (built by .github/workflows/devcontainer.yml)
-    // Features (including claude-code) are baked into this image.
-    "image": "ghcr.io/blooop/python_template/devcontainer:latest",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "features": {
+        "./claude-code": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {}
+    },
 
-    // To build locally instead of using the prebuilt image, comment out "image" above
-    // and uncomment the "build" and "features" blocks below:
-    // "build": {
-    //     "dockerfile": "Dockerfile",
-    //     "context": ".."
-    // },
-    // "features": {
-    //     "./claude-code": {},
-    //     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    //     "ghcr.io/devcontainers/features/common-utils:2": {},
-    //     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
-    //     "ghcr.io/jsburckhardt/devcontainer-features/codex:latest": {}
-    // },
+    // To use a prebuilt image instead of building locally (faster startup),
+    // comment out "build" and "features" above, uncomment "image" below,
+    // and ensure the GHCR package is public (see README).
+    // "image": "ghcr.io/blooop/python_template/devcontainer:latest",
 
     "initializeCommand": ".devcontainer/claude-code/init-host.sh",
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,8 @@
     //     "context": ".."
     // },
     // "features": {
-    //     "./claude-code": {}
-    //     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    //     "./claude-code": {},
+    //     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     //     "ghcr.io/devcontainers/features/common-utils:2": {},
     //     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     //     "ghcr.io/jsburckhardt/devcontainer-features/codex:latest": {}

--- a/README.md
+++ b/README.md
@@ -57,21 +57,20 @@ source .claude/activate.sh
 
 See [.claude/README.md](.claude/README.md) for detailed information about the Claude Code configuration.
 
-# Devcontainer Prebuilt Image
+# Devcontainer
 
-This template includes a CI workflow (`.github/workflows/devcontainer.yml`) that automatically builds and pushes a devcontainer image to GitHub Container Registry (GHCR) whenever `.devcontainer/` files change on `main`.
+By default, the devcontainer builds locally from `.devcontainer/Dockerfile`. This works out of the box for all users, including forks and projects created from this template.
 
-The main `.devcontainer/devcontainer.json` references this prebuilt image to avoid slow local builds:
+## Switching to a prebuilt image (optional)
 
-```json
-"image": "ghcr.io/blooop/python_template/devcontainer:latest"
-```
+A CI workflow (`.github/workflows/devcontainer.yml`) automatically builds and pushes a devcontainer image to GHCR whenever `.devcontainer/` files change on `main`. To use it for faster startup:
 
-## GHCR Package Visibility
+1. Edit `.devcontainer/devcontainer.json`: comment out the `"build"` and `"features"` blocks, uncomment the `"image"` line
+2. Update the image reference to match your repo: `ghcr.io/<owner>/<repo>/devcontainer:latest`
+3. Push to `main` and wait for the CI workflow to complete
+4. **Make the GHCR package public** (see below) — GHCR packages are private by default and will fail with `MANIFEST_UNKNOWN` otherwise
 
-**GHCR packages are private by default.** After the first CI push, you must manually make the package public or users (and tools like DevPod) will get a `MANIFEST_UNKNOWN` error when trying to pull the image.
-
-### Making the package public
+### Making the GHCR package public
 
 **Option 1: GitHub Web UI**
 
@@ -89,10 +88,6 @@ gh auth refresh -s write:packages
 # Set the package to public
 gh api --method PATCH /user/packages/container/<repo>%2Fdevcontainer -f visibility=public
 ```
-
-## Falling back to local builds
-
-If the prebuilt image is unavailable, you can switch to local builds by editing `.devcontainer/devcontainer.json`: comment out the `"image"` line and uncomment the `"build"` and `"features"` blocks.
 
 # Github setup
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,43 @@ source .claude/activate.sh
 
 See [.claude/README.md](.claude/README.md) for detailed information about the Claude Code configuration.
 
+# Devcontainer Prebuilt Image
+
+This template includes a CI workflow (`.github/workflows/devcontainer.yml`) that automatically builds and pushes a devcontainer image to GitHub Container Registry (GHCR) whenever `.devcontainer/` files change on `main`.
+
+The main `.devcontainer/devcontainer.json` references this prebuilt image to avoid slow local builds:
+
+```json
+"image": "ghcr.io/blooop/python_template/devcontainer:latest"
+```
+
+## GHCR Package Visibility
+
+**GHCR packages are private by default.** After the first CI push, you must manually make the package public or users (and tools like DevPod) will get a `MANIFEST_UNKNOWN` error when trying to pull the image.
+
+### Making the package public
+
+**Option 1: GitHub Web UI**
+
+1. Go to your repository's package settings:
+   `https://github.com/users/<username>/packages/container/<repo>%2Fdevcontainer/settings`
+2. Under "Danger Zone", click **Change visibility**
+3. Select **Public** and confirm
+
+**Option 2: GitHub CLI**
+
+```bash
+# Ensure your token has the write:packages scope
+gh auth refresh -s write:packages
+
+# Set the package to public
+gh api --method PATCH /user/packages/container/<repo>%2Fdevcontainer -f visibility=public
+```
+
+## Falling back to local builds
+
+If the prebuilt image is unavailable, you can switch to local builds by editing `.devcontainer/devcontainer.json`: comment out the `"image"` line and uncomment the `"build"` and `"features"` blocks.
+
 # Github setup
 
 There are github workflows for CI, codecov and automated pypi publishing in `ci.yml` and `publish.yml`.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ By default, the devcontainer builds locally from `.devcontainer/Dockerfile`. Thi
 
 ## Switching to a prebuilt image (optional)
 
-A CI workflow (`.github/workflows/devcontainer.yml`) automatically builds and pushes a devcontainer image to GHCR whenever `.devcontainer/` files change on `main`. To use it for faster startup:
+A CI workflow (`.github/workflows/devcontainer.yml`) automatically builds and pushes a devcontainer image to GHCR whenever `.devcontainer/` files change on `main`. The image is published as `ghcr.io/<owner>/<repo>/devcontainer:latest`, where `<owner>` is your GitHub username or organization and `<repo>` is the repository name (e.g. `ghcr.io/myuser/myproject/devcontainer:latest`).
+
+You can migrate automatically with:
+
+```bash
+pixi run dev-use-prebuilt
+```
+
+Or manually:
 
 1. Edit `.devcontainer/devcontainer.json`: comment out the `"build"` and `"features"` blocks, uncomment the `"image"` line
 2. Update the image reference to match your repo: `ghcr.io/<owner>/<repo>/devcontainer:latest`
@@ -75,7 +83,8 @@ A CI workflow (`.github/workflows/devcontainer.yml`) automatically builds and pu
 **Option 1: GitHub Web UI**
 
 1. Go to your repository's package settings:
-   `https://github.com/users/<username>/packages/container/<repo>%2Fdevcontainer/settings`
+   - Personal repos: `https://github.com/users/<username>/packages/container/<repo>%2Fdevcontainer/settings`
+   - Organization repos: `https://github.com/orgs/<org>/packages/container/<repo>%2Fdevcontainer/settings`
 2. Under "Danger Zone", click **Change visibility**
 3. Select **Public** and confirm
 
@@ -85,8 +94,11 @@ A CI workflow (`.github/workflows/devcontainer.yml`) automatically builds and pu
 # Ensure your token has the write:packages scope
 gh auth refresh -s write:packages
 
-# Set the package to public
+# For personal repos:
 gh api --method PATCH /user/packages/container/<repo>%2Fdevcontainer -f visibility=public
+
+# For organization repos:
+gh api --method PATCH /orgs/<org>/packages/container/<repo>%2Fdevcontainer -f visibility=public
 ```
 
 # Github setup

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Or manually:
 
 1. Edit `.devcontainer/devcontainer.json`: comment out the `"build"` and `"features"` blocks, uncomment the `"image"` line
 2. Update the image reference to match your repo: `ghcr.io/<owner>/<repo>/devcontainer:latest`
-3. Push to `main` and wait for the CI workflow to complete
+3. Push to `main` and wait for the CI workflow to complete. For new repos or forks where the workflow hasn't run yet, you can trigger it manually from the Actions tab or via `gh workflow run devcontainer.yml`
 4. **Make the GHCR package public** (see below) — GHCR packages are private by default and will fail with `MANIFEST_UNKNOWN` otherwise
 
 ### Making the GHCR package public

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ ci-push = { depends-on = ["format", "ruff-lint", "update-lock", "ci", "push"] }
 clear-pixi = "rm -rf .pixi pixi.lock"
 setup-git-merge-driver = "git config merge.ourslock.driver true"
 update-from-template-repo = "./scripts/update_from_template.sh"
+dev-use-prebuilt = "./scripts/devcontainer_use_prebuilt.sh"
 
 [tool.pylint]
 extension-pkg-whitelist = ["numpy"]

--- a/scripts/devcontainer_use_prebuilt.sh
+++ b/scripts/devcontainer_use_prebuilt.sh
@@ -101,9 +101,9 @@ else
     SETTINGS_URL="https://github.com/users/${OWNER}/packages/container/${ENCODED_PACKAGE}/settings"
 fi
 
-API_OUTPUT=$(gh api --method PATCH "$API_PATH" -f visibility=public 2>&1) && {
+if API_OUTPUT=$(gh api --method PATCH "$API_PATH" -f visibility=public 2>&1); then
     echo "GHCR package is now public."
-} || {
+else
     echo "Could not set package visibility automatically."
     echo "API response: $API_OUTPUT"
     echo ""

--- a/scripts/devcontainer_use_prebuilt.sh
+++ b/scripts/devcontainer_use_prebuilt.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+# Migrate devcontainer.json from local builds to a prebuilt GHCR image.
+# Also attempts to make the GHCR package public.
+
+DEVCONTAINER_JSON=".devcontainer/devcontainer.json"
+
+# --- Resolve GitHub owner/repo from git remote ---
+REMOTE_URL=$(git remote get-url origin 2>/dev/null) || {
+    echo "ERROR: No git remote 'origin' found." >&2
+    exit 1
+}
+
+# Handle ssh (git@github.com:owner/repo.git) and https URLs
+REPO=$(echo "$REMOTE_URL" | sed -E 's#(git@github\.com:|https://github\.com/)##; s/\.git$//')
+
+if [[ -z "$REPO" || "$REPO" != */* ]]; then
+    echo "ERROR: Could not parse owner/repo from remote URL: $REMOTE_URL" >&2
+    exit 1
+fi
+
+IMAGE="ghcr.io/${REPO}/devcontainer:latest"
+echo "Repository: $REPO"
+echo "Image:      $IMAGE"
+
+# --- Check current state: look for an uncommented "image": line ---
+if grep -qP '^\s+"image"\s*:' "$DEVCONTAINER_JSON"; then
+    echo "Already using a prebuilt image. Nothing to do."
+    exit 0
+fi
+
+# --- Replace the file using awk for reliable block manipulation ---
+awk -v image="$IMAGE" '
+    # Comment out uncommented "build" block (4-space indent open/close)
+    /^    "build": \{/ { in_build=1 }
+    in_build {
+        sub(/^    /, "    // ")
+        if (/^    \/\/ \}/) in_build=0
+        print; next
+    }
+
+    # Comment out uncommented "features" block (4-space indent open/close)
+    /^    "features": \{/ { in_features=1 }
+    in_features {
+        sub(/^    /, "    // ")
+        if (/^    \/\/ \}/) in_features=0
+        print; next
+    }
+
+    # Uncomment the image line and set the correct reference
+    /^    \/\/ "image":/ {
+        printf "    \"image\": \"%s\",\n", image
+        next
+    }
+
+    { print }
+' "$DEVCONTAINER_JSON" > "${DEVCONTAINER_JSON}.tmp" && mv "${DEVCONTAINER_JSON}.tmp" "$DEVCONTAINER_JSON"
+
+echo ""
+echo "Updated $DEVCONTAINER_JSON to use prebuilt image."
+
+# --- Try to make the GHCR package public ---
+echo ""
+echo "Attempting to make GHCR package public..."
+
+PACKAGE_NAME=$(echo "$REPO" | cut -d'/' -f2)
+ENCODED_PACKAGE="${PACKAGE_NAME}%2Fdevcontainer"
+
+if gh api --method PATCH "/user/packages/container/${ENCODED_PACKAGE}" -f visibility=public >/dev/null 2>&1; then
+    echo "GHCR package is now public."
+else
+    echo "Could not set package visibility automatically."
+    echo ""
+    echo "To make the package public manually, either:"
+    echo ""
+    echo "  1. Visit: https://github.com/users/$(echo "$REPO" | cut -d'/' -f1)/packages/container/${ENCODED_PACKAGE}/settings"
+    echo "     -> Danger Zone -> Change visibility -> Public"
+    echo ""
+    echo "  2. Run:"
+    echo "     gh auth refresh -s write:packages"
+    echo "     gh api --method PATCH /user/packages/container/${ENCODED_PACKAGE} -f visibility=public"
+fi


### PR DESCRIPTION
## Summary
- Document that GHCR packages are private by default, causing `MANIFEST_UNKNOWN` errors when pulling the prebuilt devcontainer image
- Add instructions for making the package public via GitHub UI and CLI (`gh api`)
- Fix missing commas in commented-out features block in `devcontainer.json`

## Context
After merging #136 (prebuilt devcontainer images), `devpod up .` fails with:
```
GET https://ghcr.io/v2/blooop/python_template/devcontainer/manifests/latest: MANIFEST_UNKNOWN: manifest unknown
```
This is because GHCR packages default to private visibility. The image exists but isn't accessible without authentication.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Make the package public using the documented instructions
- [ ] Confirm `devpod up .` works after making the package public

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document how to use prebuilt devcontainer images from GHCR and provide tooling to switch an existing devcontainer to a public prebuilt image.

New Features:
- Add a helper script to migrate the devcontainer configuration from local builds to a prebuilt GHCR image and set the correct image reference.
- Add a dedicated dev task alias for switching the devcontainer to use the prebuilt image.

Enhancements:
- Expand README with instructions for enabling prebuilt devcontainer images and making the associated GHCR package public via UI or GitHub CLI.

Documentation:
- Document devcontainer behavior, how to switch to a prebuilt GHCR image, and how to change GHCR package visibility to public.