### PR TITLE
Default devcontainer to template's prebuilt image

### DIFF
--- a/.devcontainer/ci/devcontainer.json
+++ b/.devcontainer/ci/devcontainer.json
@@ -5,6 +5,8 @@
         "context": "../.."
     },
     "features": {
-        "../claude-code": {}
+        "../claude-code": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {}
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,20 @@
 {
     "name": "python_template",
 
-    "build": {
-        "dockerfile": "Dockerfile",
-        "context": ".."
-    },
+    // Uses the template's prebuilt image by default for fast startup.
+    // To build locally: pixi run dev-use-local
+    // To use this repo's own prebuilt image: pixi run dev-use-prebuilt
+    // "build": {
+    //     "dockerfile": "Dockerfile",
+    //     "context": ".."
+    // },
+    "image": "ghcr.io/blooop/python_template/devcontainer:latest",
+
     "features": {
         "./claude-code": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/common-utils:2": {}
     },
-
-    // To use a prebuilt image instead of building locally (faster startup),
-    // comment out "build" and "features" above, uncomment "image" below,
-    // and ensure the GHCR package is public (see README).
-    // "image": "ghcr.io/blooop/python_template/devcontainer:latest",
 
     "initializeCommand": ".devcontainer/claude-code/init-host.sh",
     "customizations": {

--- a/README.md
+++ b/README.md
@@ -59,47 +59,29 @@ See [.claude/README.md](.claude/README.md) for detailed information about the Cl
 
 # Devcontainer
 
-By default, the devcontainer builds locally from `.devcontainer/Dockerfile`. This works out of the box for all users, including forks and projects created from this template.
+The devcontainer has three states:
 
-## Switching to a prebuilt image (optional)
+| State | When | `image` | `build` | `features` |
+|---|---|---|---|---|
+| **Template prebuilt** (default) | Fresh clones, after rename | template URL | commented | active |
+| **Local build** | After `dev-use-local` | commented | active | active |
+| **Repo prebuilt** | After `dev-use-prebuilt` | repo URL | commented | commented |
 
-A CI workflow (`.github/workflows/devcontainer.yml`) automatically builds and pushes a devcontainer image to GHCR whenever `.devcontainer/` files change on `main`. The image is published as `ghcr.io/<owner>/<repo>/devcontainer:latest`, where `<owner>` is your GitHub username or organization and `<repo>` is the repository name (e.g. `ghcr.io/myuser/myproject/devcontainer:latest`).
+By default, the devcontainer uses a prebuilt image from the template repository (`ghcr.io/blooop/python_template/devcontainer:latest`) for fast startup. This works immediately for new repos created from this template — no CI build needed.
 
-You can migrate automatically with:
+To switch to building locally from `.devcontainer/Dockerfile` (e.g. after customizing the Dockerfile):
+
+```bash
+pixi run dev-use-local
+```
+
+To switch to this repo's own prebuilt image (built by CI on each push to `main`):
 
 ```bash
 pixi run dev-use-prebuilt
 ```
 
-Or manually:
-
-1. Edit `.devcontainer/devcontainer.json`: comment out the `"build"` and `"features"` blocks, uncomment the `"image"` line
-2. Update the image reference to match your repo: `ghcr.io/<owner>/<repo>/devcontainer:latest`
-3. Push to `main` and wait for the CI workflow to complete. For new repos or forks where the workflow hasn't run yet, you can trigger it manually from the Actions tab or via `gh workflow run devcontainer.yml`
-4. **Make the GHCR package public** (see below) — GHCR packages are private by default and will fail with `MANIFEST_UNKNOWN` otherwise
-
-### Making the GHCR package public
-
-**Option 1: GitHub Web UI**
-
-1. Go to your repository's package settings:
-   - Personal repos: `https://github.com/users/<username>/packages/container/<repo>%2Fdevcontainer/settings`
-   - Organization repos: `https://github.com/orgs/<org>/packages/container/<repo>%2Fdevcontainer/settings`
-2. Under "Danger Zone", click **Change visibility**
-3. Select **Public** and confirm
-
-**Option 2: GitHub CLI**
-
-```bash
-# Ensure your token has the write:packages scope
-gh auth refresh -s write:packages
-
-# For personal repos:
-gh api --method PATCH /user/packages/container/<repo>%2Fdevcontainer -f visibility=public
-
-# For organization repos:
-gh api --method PATCH /orgs/<org>/packages/container/<repo>%2Fdevcontainer -f visibility=public
-```
+This detects the repo from git remote, updates `devcontainer.json` to use `ghcr.io/<owner>/<repo>/devcontainer:latest`, and attempts to make the GHCR package public. See the script output for manual steps if automatic visibility fails.
 
 # Github setup
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1177,16 +1177,16 @@ packages:
 - pypi: ./
   name: python-template
   version: 0.2.0
-  sha256: 6d3e551e4f8b8f76a3e83c3f917fe60cc708faa31f68dbf04ddd84c0edef95e5
+  sha256: ec4ead2bc1d847e3ea1871e222dc27b3bd160c64249ca537c03f457e84df29e6
   requires_dist:
   - pylint>=3.2.5,<=4.0.4 ; extra == 'test'
   - pytest-cov>=4.1,<=7.0.0 ; extra == 'test'
   - pytest>=7.4,<=9.0.2 ; extra == 'test'
-  - hypothesis>=6.104.2,<=6.150.2 ; extra == 'test'
-  - ruff>=0.5.0,<=0.14.13 ; extra == 'test'
-  - coverage>=7.5.4,<=7.13.1 ; extra == 'test'
-  - prek>=0.2.28,<0.3.0 ; extra == 'test'
-  - ty>=0.0.12,<=0.0.12 ; extra == 'test'
+  - hypothesis>=6.104.2,<=6.151.5 ; extra == 'test'
+  - ruff>=0.5.0,<=0.15.0 ; extra == 'test'
+  - coverage>=7.5.4,<=7.13.4 ; extra == 'test'
+  - prek>=0.2.28,<0.4.0 ; extra == 'test'
+  - ty>=0.0.12,<=0.0.15 ; extra == 'test'
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
   build_number: 8
   sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ clear-pixi = "rm -rf .pixi pixi.lock"
 setup-git-merge-driver = "git config merge.ourslock.driver true"
 update-from-template-repo = "./scripts/update_from_template.sh"
 dev-use-prebuilt = "./scripts/devcontainer_use_prebuilt.sh"
+dev-use-local = "./scripts/devcontainer_use_local.sh"
 
 [tool.pylint]
 extension-pkg-whitelist = ["numpy"]

--- a/scripts/devcontainer_use_local.sh
+++ b/scripts/devcontainer_use_local.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Switch devcontainer.json to build locally from Dockerfile.
+
+DEVCONTAINER_JSON=".devcontainer/devcontainer.json"
+
+# Already using local build?
+if grep -q '^[[:space:]]*"build"' "$DEVCONTAINER_JSON"; then
+    echo "Already using local build. Nothing to do."
+    exit 0
+fi
+
+awk '
+    # Uncomment commented build block
+    /^    \/\/ "build": \{/ { in_build=1 }
+    in_build {
+        sub(/^    \/\/ /, "    ")
+        if (/^    \}/) in_build=0
+        print; next
+    }
+
+    # Uncomment commented features block
+    /^    \/\/ "features": \{/ { in_features=1 }
+    in_features {
+        sub(/^    \/\/ /, "    ")
+        if (/^    \}/) in_features=0
+        print; next
+    }
+
+    # Comment out uncommented image line
+    /^    "image":/ {
+        sub(/^    /, "    // ")
+        print; next
+    }
+
+    { print }
+' "$DEVCONTAINER_JSON" > "${DEVCONTAINER_JSON}.tmp" && mv "${DEVCONTAINER_JSON}.tmp" "$DEVCONTAINER_JSON"
+
+echo "Switched to local build from Dockerfile."

--- a/scripts/rename_project.sh
+++ b/scripts/rename_project.sh
@@ -2,8 +2,11 @@
 
 mv python_template "$1"
 
-# change project name in all files
-find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh' -not -name 'pixi.lock' \) -print0 | xargs -0 sed -i "s/python_template/$1/g"
+# change project name in all files (exclude main devcontainer.json to protect template image URL)
+find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh' -not -name 'pixi.lock' -not -path './.devcontainer/devcontainer.json' \) -print0 | xargs -0 sed -i "s/python_template/$1/g"
+
+# update just the name field in devcontainer.json
+sed -i "s/\"name\": \"python_template\"/\"name\": \"$1\"/" .devcontainer/devcontainer.json
 
 # regenerate lockfile to match renamed project
 pixi update
@@ -18,7 +21,7 @@ if [ -n "$3" ]; then
     find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/blooop@gmail.com/$3/g"
 fi
 
-# github username
+# github username (exclude main devcontainer.json to protect template image URL)
 if [ -n "$4" ]; then
-    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'setup_host.sh' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/blooop/$4/g"
+    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'setup_host.sh' -not -name 'update_from_template.sh' -not -path './.devcontainer/devcontainer.json' \) -print0 | xargs -0 sed -i "s/blooop/$4/g"
 fi

--- a/scripts/rename_project.sh
+++ b/scripts/rename_project.sh
@@ -1,27 +1,35 @@
 #!/bin/bash
 
+# Escape characters special in sed replacement strings (\, &, /)
+escape_sed() { printf '%s\n' "$1" | sed 's/[\\&/]/\\&/g'; }
+
 mv python_template "$1"
 
+ESCAPED_1=$(escape_sed "$1")
+
 # change project name in all files (exclude main devcontainer.json to protect template image URL)
-find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh' -not -name 'pixi.lock' -not -path './.devcontainer/devcontainer.json' \) -print0 | xargs -0 sed -i "s/python_template/$1/g"
+find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh' -not -name 'pixi.lock' -not -path './.devcontainer/devcontainer.json' \) -print0 | xargs -0 sed -i "s/python_template/$ESCAPED_1/g"
 
 # update just the name field in devcontainer.json
-sed -i "s/\"name\": \"python_template\"/\"name\": \"$1\"/" .devcontainer/devcontainer.json
+sed -i "s/\"name\": \"python_template\"/\"name\": \"$ESCAPED_1\"/" .devcontainer/devcontainer.json
 
 # regenerate lockfile to match renamed project
 pixi update
 
 # author name
 if [ -n "$2" ]; then
-    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/Austin Gregg-Smith/$2/g"
+    ESCAPED_2=$(escape_sed "$2")
+    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/Austin Gregg-Smith/$ESCAPED_2/g"
 fi
 
 # author email
 if [ -n "$3" ]; then
-    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/blooop@gmail.com/$3/g"
+    ESCAPED_3=$(escape_sed "$3")
+    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'tasks.json' -not -name 'update_from_template.sh'  \) -print0 | xargs -0 sed -i "s/blooop@gmail.com/$ESCAPED_3/g"
 fi
 
 # github username (exclude main devcontainer.json to protect template image URL)
 if [ -n "$4" ]; then
-    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'setup_host.sh' -not -name 'update_from_template.sh' -not -path './.devcontainer/devcontainer.json' \) -print0 | xargs -0 sed -i "s/blooop/$4/g"
+    ESCAPED_4=$(escape_sed "$4")
+    find . \( -type d -name .git -prune \) -o \( -type f -not -name 'setup_host.sh' -not -name 'update_from_template.sh' -not -path './.devcontainer/devcontainer.json' \) -print0 | xargs -0 sed -i "s/blooop/$ESCAPED_4/g"
 fi


### PR DESCRIPTION
## Summary
- Default `devcontainer.json` to the template's prebuilt GHCR image (`ghcr.io/blooop/python_template/devcontainer:latest`) so new repos get fast startup without waiting for CI
- Add `dev-use-local` script/task to switch to local Dockerfile builds
- Fix awk bug in both switching scripts where `if (/\}/)` matched `{}` inside feature values (e.g. `"./claude-code": {}`), causing premature block termination and invalid JSONC output
- Add `docker-in-docker` and `common-utils` features to CI devcontainer for self-contained images
- Protect template image URL during `rename_project.sh` (only the `"name"` field is updated)
- Document the three devcontainer states (template-prebuilt, local-build, repo-prebuilt) in README

## Three devcontainer states

| State | `image` | `build` | `features` | When |
|---|---|---|---|---|
| **Template prebuilt** (default) | template URL | commented | active | Fresh clones, after rename |
| **Local build** | commented | active | active | After `dev-use-local` |
| **Repo prebuilt** | repo URL | commented | commented | After `dev-use-prebuilt` |

## Test plan
- [x] `shellcheck` passes on both scripts
- [x] All state transitions tested: template→local, local→repo, repo→local, template→repo
- [x] Idempotency verified: running each script twice in same state exits early
- [x] JSONC validity confirmed after each transition (strip comments, parse as JSON)
- [x] `rename_project.sh` preserves template image URL, only updates `"name"` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Default the devcontainer to the template’s prebuilt image while supporting easy switching between local and repo-specific prebuilt devcontainers.

New Features:
- Add a dev-use-local script/task to switch the devcontainer back to building from the local Dockerfile.
- Support using this repository’s own prebuilt devcontainer image via an updated dev-use-prebuilt script that detects the repo from git remote.

Bug Fixes:
- Fix devcontainer state transition scripts so they reliably toggle image, build, and features blocks without corrupting devcontainer.json.

Enhancements:
- Document and formalize the three devcontainer states (template prebuilt, local build, repo prebuilt) in the README.
- Update devcontainer configuration and CI devcontainer setup to work smoothly with prebuilt images and local builds, including improved image handling in devcontainer.json.
- Make rename_project.sh preserve the template devcontainer image URL while still updating the devcontainer name field.

Documentation:
- Rewrite the devcontainer section of the README to explain the three devcontainer states and how to switch between them.