### PR TITLE
turn off features in ci devcontainer

### DIFF
--- a/.devcontainer/ci/devcontainer.json
+++ b/.devcontainer/ci/devcontainer.json
@@ -6,7 +6,7 @@
     },
     "features": {
         "../claude-code": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/common-utils:2": {}
+        // "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        // "ghcr.io/devcontainers/features/common-utils:2": {}
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Adjust devcontainer configuration for CI environment to disable development features not needed in continuous integration.