### PR TITLE
Replace custom merge driver with built-in merge=ours

### DIFF
--- a/.claude/hooks/SessionStart
+++ b/.claude/hooks/SessionStart
@@ -34,10 +34,6 @@ pixi install
 echo "🔧 Setting up prek hooks..."
 pixi run prek install || echo "⚠️  Prek installation skipped (optional)"
 
-# Set up git merge driver for lockfiles
-echo "🔧 Configuring git merge driver..."
-pixi run setup-git-merge-driver || true
-
 echo "✅ Environment setup complete!"
 echo ""
 echo "Available pixi tasks:"

--- a/.gitattributes
+++ b/.gitattributes
@@ -43,4 +43,4 @@
 # numpy file format
 *.npy filter=lfs diff=lfs merge=lfs -text
 # GitHub syntax highlighting
-pixi.lock linguist-language=YAML merge=ourslock
+pixi.lock linguist-language=YAML merge=ours

--- a/pixi.lock
+++ b/pixi.lock
@@ -883,7 +883,7 @@ packages:
 - pypi: ./
   name: python-template
   version: 0.2.0
-  sha256: 3c39f0339b9f9a48257dbbcd88fe4a65363187b4ad866ac1f353cfce4144b443
+  sha256: acd5064f3b5d5b49096fa258d515a3d9d1eeb600f8d84fa08720b886965ee68e
   requires_dist:
   - pylint>=3.2.5,<=4.0.5 ; extra == 'test'
   - pytest-cov>=4.1,<=7.0.0 ; extra == 'test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ ci = { depends-on = [
 ci-push = { depends-on = ["format", "ruff-lint", "update-lock", "ci", "push"] }
 clear-pixi = "rm -rf .pixi pixi.lock"
 ralph = "ralph"
-setup-git-merge-driver = "git config merge.ourslock.driver true"
 update-from-template-repo = "./scripts/update_from_template.sh"
 dev-use-prebuilt = "./scripts/devcontainer_use_prebuilt.sh"
 dev-use-local = "./scripts/devcontainer_use_local.sh"


### PR DESCRIPTION
## Summary
- Replaced the custom `ourslock` merge driver with Git's built-in `merge=ours` driver in `.gitattributes`
- Removed the `setup-git-merge-driver` pixi task from `pyproject.toml`
- Removed the merge driver setup block from `.claude/hooks/SessionStart`

The custom driver required per-clone `git config` setup which was fragile — if missed, Git silently fell back to 3-way merge producing nonsensical conflicts in `pixi.lock`. The built-in `merge=ours` works from `.gitattributes` alone with zero local configuration.

## Test plan
- [x] `git check-attr merge pixi.lock` returns `merge: ours`
- [x] `pixi task list | grep merge` returns nothing
- [x] `pixi run ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the custom pixi.lock merge driver setup with Git's built-in merge=ours configuration and remove associated local setup hooks and tasks.

Build:
- Remove the pixi task that configured the custom ourslock Git merge driver from pyproject.toml.

Chores:
- Remove the custom merge driver setup block from the Claude SessionStart hook and rely on .gitattributes using merge=ours for pixi.lock.