### PR TITLE
install prek by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,5 +47,5 @@
         "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind",
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
     ],
-    "postCreateCommand": "sudo chown vscode .pixi && pixi install"
+    "postCreateCommand": "sudo chown vscode .pixi && pixi install && pixi run prek-install"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,8 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi ]
   # Shell script linter
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -883,7 +883,7 @@ packages:
 - pypi: ./
   name: python-template
   version: 0.2.0
-  sha256: 3c39f0339b9f9a48257dbbcd88fe4a65363187b4ad866ac1f353cfce4144b443
+  sha256: 16eb40e2f9baefe70d4e5033d2da6c9906194e834eaf9f699158c78952af4836
   requires_dist:
   - pylint>=3.2.5,<=4.0.5 ; extra == 'test'
   - pytest-cov>=4.1,<=7.0.0 ; extra == 'test'

--- a/pixi.lock
+++ b/pixi.lock
@@ -883,7 +883,7 @@ packages:
 - pypi: ./
   name: python-template
   version: 0.2.0
-  sha256: acd5064f3b5d5b49096fa258d515a3d9d1eeb600f8d84fa08720b886965ee68e
+  sha256: b57684cbca9be991704582f3d6f8070a9db494464673e72274caa9855fc2f76f
   requires_dist:
   - pylint>=3.2.5,<=4.0.5 ; extra == 'test'
   - pytest-cov>=4.1,<=7.0.0 ; extra == 'test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev-vs = { cmd = "devpod up . --ide vscode", depends-on = ["dev-add-docker"] }
 dev-restart = { cmd = "devpod up . --recreate --ide none && ssh pythontemplate.devpod", depends-on = ["dev-add-docker"] }
 dev-restart-vs = { cmd = "devpod up . --recreate --ide vscode", depends-on = ["dev-add-docker"] }
 prek = "prek run -a"
+prek-install = "prek install"
 prek-update = "prek autoupdate"
 format = "ruff format ."
 check-clean-workspace = "git diff --exit-code"


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated task to run `prek install` by default in the project tooling.

New Features:
- Introduce a `prek-install` task command to simplify running `prek install` via the project task runner.

Build:
- Update project task configuration to include a `prek-install` command for Prek setup.