### PR TITLE
fix: configure ours merge driver for pixi.lock

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,5 +47,5 @@
         "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind",
         "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
     ],
-    "postCreateCommand": "sudo chown vscode .pixi && pixi install"
+    "postCreateCommand": "sudo chown vscode .pixi && git config merge.ours.driver true && pixi install"
 }


### PR DESCRIPTION
## Summary

- `merge=ours` in `.gitattributes` is **not** a built-in git merge driver (built-ins are only `text`, `binary`, `union`). Without defining it, git falls back to the `text` driver and still reports conflicts on `pixi.lock`.
- Adds `git config merge.ours.driver true` to devcontainer `postCreateCommand`, which defines the custom merge driver so `pixi.lock` conflicts auto-resolve by keeping "ours".

## Test plan

- [x] Verified without the driver config: merge reports `CONFLICT` and fails
- [x] Verified with the driver config: merge completes cleanly (exit 0), keeps "ours" content, no conflict markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add devcontainer post-create git configuration to register the custom 'ours' merge driver used for pixi.lock.