### PR TITLE
fix: update_from_template.sh fails on first run

### DIFF
--- a/scripts/update_from_template.sh
+++ b/scripts/update_from_template.sh
@@ -1,13 +1,17 @@
 #! /bin/bash
 set -eo pipefail
 
+TEMPLATE_URL="https://github.com/blooop/python_template.git"
+BRANCH="feature/update_from_template"
+
 git config --global pull.rebase false
-git remote add template https://github.com/blooop/python_template.git
+git remote remove template 2>/dev/null || true
+git remote add template "$TEMPLATE_URL"
 git fetch --all
 git checkout main && git pull origin main
-git checkout -B feature/update_from_template; git pull
+git checkout -B "$BRANCH"
 git merge template/main --allow-unrelated-histories -m 'feat: pull changes from remote template'
-git checkout --ours pixi.lock
+git checkout --ours pixi.lock 2>/dev/null || true
 
 # regenerate lockfile to match merged pyproject.toml
 pixi update
@@ -15,5 +19,5 @@ git add pixi.lock
 git diff --cached --quiet || git commit -m 'chore: update pixi.lock after template merge'
 
 git remote remove template
-git push --set-upstream origin feature/update_from_template
+git push --set-upstream origin "$BRANCH"
 git checkout main

--- a/scripts/update_from_template.sh
+++ b/scripts/update_from_template.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
 set -eo pipefail
 
-TEMPLATE_URL="https://github.com/blooop/python_template.git"
-BRANCH="feature/update_from_template"
+TEMPLATE_URL="${TEMPLATE_URL:-https://github.com/blooop/python_template.git}"
+BRANCH="${BRANCH:-feature/update_from_template}"
 
-git config --global pull.rebase false
+git config pull.rebase false
 git remote remove template 2>/dev/null || true
 git remote add template "$TEMPLATE_URL"
 git fetch --all


### PR DESCRIPTION
## Summary

- **Remove `git pull` after `git checkout -B`** — on a newly created branch with no upstream, `git pull` fails and `set -eo pipefail` kills the script before the template merge ever runs. This was the root cause of the template history not being merged into downstream repos.
- **Idempotent remote handling** — remove the `template` remote before adding it, so re-runs after a crash don't fail at `git remote add`.
- **Guard `git checkout --ours pixi.lock`** — suppress errors when there's no merge conflict on that file.
- Extract template URL and branch name into variables.

## Test plan
- [ ] Create a new repo from the template (fresh "Initial commit", no shared history)
- [ ] Run `scripts/update_from_template.sh` — should complete and produce a merge commit with `--allow-unrelated-histories`
- [ ] Run the script a second time to verify idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix the template update script so it reliably creates and updates the template merge branch, even on first run against a repo with no shared history.

Bug Fixes:
- Prevent update_from_template.sh from failing on first run due to pulling on a new local branch without an upstream.
- Ensure repeated runs of update_from_template.sh do not fail when the template remote already exists.
- Avoid errors when updating pixi.lock if there is no merge conflict for that file.

Enhancements:
- Introduce variables for the template repository URL and update branch name to simplify configuration and reuse.