### PR TITLE
chore: bump pixi to v0.75.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PIXI_VERSION=v0.65.0
+ARG PIXI_VERSION=v0.75.0
 
 RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \


### PR DESCRIPTION
Bumps the `PIXI_VERSION` build arg in `.devcontainer/Dockerfile` from `v0.65.0` to `v0.75.0` (current latest release of prefix-dev/pixi).

This is the only place pixi's own version is pinned in the repo — CI uses `prefix-dev/setup-pixi@v0.9.5`, which resolves pixi separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)